### PR TITLE
chore: updated image, fix-font

### DIFF
--- a/src/components/ImageMod.astro
+++ b/src/components/ImageMod.astro
@@ -14,6 +14,7 @@ interface Props {
   format?: "auto" | "avif" | "jpeg" | "png" | "svg" | "webp";
   class?: string;
   style?: any;
+  fit?: "cover" | "contain" | "fill" | "none" | "scale-down";
 }
 
 // Destructuring Astro.props to get the component's props
@@ -28,6 +29,7 @@ let {
   class: className,
   format,
   style,
+  fit,
 } = Astro.props;
 
 
@@ -59,6 +61,7 @@ const isValidPath = images[src] ? true : false;
       class={className}
       format={format}
       style={style}
+      fit={fit ? fit : "contain"}
     />
   )
 }


### PR DESCRIPTION
This PR adds:\n\n1. **ImageMod.astro**: Added optional `fit` prop with support for "cover", "contain", "fill", "none", "scale-down" values.\n2. **astro.config.mjs**: Fixed font parsing to replace + with spaces in font names.