### PR TITLE
chore: update to Astro v6 stable and switch to built-in Fonts API

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,15 +1,52 @@
 // @ts-check
-import { defineConfig } from "astro/config";
+import { defineConfig, fontProviders } from "astro/config";
 import starlight from "@astrojs/starlight";
 import { viewTransitions } from "astro-vtbot/starlight-view-transitions";
 
 import tailwindcss from "@tailwindcss/vite";
 import config from "./src/config/config.json" assert { type: "json" };
+import theme from "./src/config/theme.json" assert { type: "json" };
 import social from "./src/config/social.json";
 import locals from "./src/config/locals.json";
 import sidebar from "./src/config/sidebar.json";
 
 import { fileURLToPath } from "url";
+
+// Helper to parse font string format: "FontName:wght@400;500;600;700"
+function parseFontString(fontStr) {
+  const [name, weightPart] = fontStr.split(":");
+  let weights = [400]; // default weight
+
+  if (weightPart) {
+    // Extract weights from wght@400;500;600 format
+    const weightMatch = weightPart.match(/wght@?([\d;]+)/);
+    if (weightMatch) {
+      weights = weightMatch[1].split(";").map((w) => parseInt(w, 10));
+    }
+  }
+
+  // remove + from font name and add space
+  const cleanName = name.replace(/\+/g, " ");
+  return { name: cleanName, weights };
+}
+
+// Build fonts configuration from theme.json
+const fontsConfig = Object.entries(theme.fonts.font_family)
+  .filter(([key]) => !key.includes("_type")) // Filter out type entries
+  .map(([key, fontStr]) => {
+    const { name, weights } = parseFontString(fontStr);
+    const typeKey = `${key}_type`;
+    const fallback = theme.fonts.font_family[typeKey] || "sans-serif";
+
+    return {
+      name,
+      cssVariable: `--font-${key}`,
+      provider: fontProviders.google(),
+      weights,
+      display: "swap",
+      fallbacks: [fallback],
+    };
+  });
 
 const { site } = config;
 const { title, logo, logo_darkmode } = site;
@@ -22,6 +59,7 @@ export default defineConfig({
   image: {
     service: { entrypoint: "astro/assets/services/noop" },
   },
+  fonts: fontsConfig,
   integrations: [
     starlight({
       title,

--- a/package.json
+++ b/package.json
@@ -15,9 +15,8 @@
     "@astrojs/starlight": "^0.37.0",
     "@astrojs/starlight-tailwind": "^4.0.2",
     "@tailwindcss/vite": "^4.1.17",
-    "astro": "^5.16.4",
+    "astro": "^6.0.0",
     "astro-embed": "^0.9.2",
-    "astro-font": "^1.1.0",
     "marked": "^17.0.1",
     "sharp": "^0.34.5",
     "vite": "^7.2.6"


### PR DESCRIPTION
This PR updates the theme to Astro v6 stable and replaces the third-party astro-font package with the built-in Fonts API.\n\n## Changes:\n- Updated Astro from ^5.16.4 to ^6.0.0\n- Removed astro-font package dependency\n- Added fontProviders import from astro/config\n- Added parseFontString helper function to parse font strings from theme.json\n- Configured built-in Fonts API with fontsConfig\n- Updated return statement in parseFontString to clean font names (replace + with spaces)